### PR TITLE
fixed signup button glitch

### DIFF
--- a/frontend/stayNest/src/components/Home.jsx
+++ b/frontend/stayNest/src/components/Home.jsx
@@ -637,19 +637,32 @@ const Home = () => {
           <h2 className="text-3xl font-extrabold text-white sm:text-4xl">
             <span className="block">Ready to start your journey?</span>
             <span className="block">
-              Start booking your next adventure today.
+              {isAuthenticated
+                ? "Explore amazing places to stay."
+                : "Start booking your next adventure today."}
             </span>
           </h2>
           <p className="mt-4 text-lg leading-6 text-blue-200">
-            Join thousands of travelers who have found their perfect stay with
-            us.
+            {isAuthenticated
+              ? "Discover your next perfect getaway from our curated collection of properties."
+              : "Join thousands of travelers who have found their perfect stay with us."}
           </p>
-          <Link
-            to="/register"
-            className="mt-8 w-full inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-blue-600 bg-white hover:bg-blue-50 sm:w-auto"
-          >
-            Sign up for free
-          </Link>
+          {!isAuthenticated && (
+            <Link
+              to="/register"
+              className="mt-8 w-full inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-blue-600 bg-white hover:bg-blue-50 sm:w-auto"
+            >
+              Sign up for free
+            </Link>
+          )}
+          {isAuthenticated && (
+            <Link
+              to="/properties"
+              className="mt-8 w-full inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-blue-600 bg-white hover:bg-blue-50 sm:w-auto"
+            >
+              Explore Properties
+            </Link>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### **User description**
After logging in or signing up still in footer section the sign up for free button was appearing which I fixed with conditional rendering , changed the button to explore properties


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
• Fixed signup button appearing for authenticated users
• Added conditional rendering based on authentication state
• Updated CTA section text and button for logged-in users
• Replaced signup button with "Explore Properties" for authenticated users


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Home.jsx</strong><dd><code>Conditional CTA section based on authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/stayNest/src/components/Home.jsx

• Added conditional rendering to hide signup button for authenticated <br>users<br> • Updated CTA section heading and description text based on <br>authentication state<br> • Added "Explore Properties" button for <br>authenticated users linking to <code>/properties</code><br> • Wrapped signup button in <br>authentication check to prevent display when logged in


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S85_Rajeev_Ranjan_Mandal_Capstone_StayNest/pull/53/files#diff-097f36dae9a3f3fcb15f66fda2d87bdfd3c4363e8110a9b8bda37ca95f27d295">+22/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>